### PR TITLE
Remove useless shebang lines

### DIFF
--- a/signature_dispatch.py
+++ b/signature_dispatch.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """
 Execute the first function that matches the given arguments.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import sys, re
 
 def pytest_ignore_collect(path, config):

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import signature_dispatch as sd, pytest
 from typing import List, Callable
 

--- a/tests/test_python38.py
+++ b/tests/test_python38.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import signature_dispatch
 import pytest
 


### PR DESCRIPTION
These sources are not script-like (have no “`if __name__ == __main__”` or similar) and do not have the executable bit set, so the shebang lines are not useful.