### PR TITLE
Migrate to typeguard v4.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,16 +94,16 @@ invoke::
   TypeError: can't dispatch the given arguments to any of the candidate functions:
   arguments: 'a'
   candidates:
-  (x: int): type of x must be int; got str instead
-  (x: List[int]): type of x must be a list; got str instead
+  (x: int): x: str is not an instance of int
+  (x: List[int]): x: str is not a list
   >>> f2(['a'])
   Traceback (most recent call last):
       ...
   TypeError: can't dispatch the given arguments to any of the candidate functions:
   arguments: ['a']
   candidates:
-  (x: int): type of x must be int; got list instead
-  (x: List[int]): type of x[0] must be int; got str instead
+  (x: int): x: list is not an instance of int
+  (x: List[int]): x: item 0 of list is not an instance of int
 
 Details
 =======

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ home-page = 'https://github.com/kalekundert/signature_dispatch'
 description-file = 'README.rst'
 requires-python = "~=3.7"
 requires = [
-  'typeguard~=3.0',
+  'typeguard~=4.0',
 ]
 classifiers = [
   'Programming Language :: Python :: 3',


### PR DESCRIPTION
The [typeguard](https://github.com/agronholm/typeguard/) dependency is working on yet another major version, currently at `rc3`. Assuming there are no further functional changes, this PR should suffice when the 4.0.0 release is ready.